### PR TITLE
Removed attribute for mysql client bin

### DIFF
--- a/recipes/mysql.rb
+++ b/recipes/mysql.rb
@@ -11,7 +11,7 @@ template sql_path do
 end
 
 execute "phpmyadmin-create-tables" do
-  command "\"#{node['mysql']['mysql_bin']}\" -u root #{node['mysql']['server_root_password'].empty? ? '' : '-p' }\"#{node['mysql']['server_root_password']}\" < \"#{sql_path}\""
+  command "/usr/bin/mysql -u root #{node['mysql']['server_root_password'].empty? ? '' : '-p' }\"#{node['mysql']['server_root_password']}\" < \"#{sql_path}\""
 end
 
 file sql_path do


### PR DESCRIPTION
It doesn't exists. I can't find any usable attribute in opscode-cookbooks/mysql.
